### PR TITLE
Added the ability to specify a custom file name

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -5,7 +5,8 @@ use Illuminate\Support\Facades\Storage;
 
 foreach (config('local-temporary-url.disk') as $disk) {
     Route::get("$disk/temp/{path}", function (string $path) use ($disk) {
-        return Storage::disk($disk)->download($path);
+        $filename = request('filename', null);
+        return Storage::disk($disk)->download($path, $filename);
     })
         ->where('path', '.*')
         ->middleware(config('local-temporary-url.middleware'))


### PR DESCRIPTION
If the temporary URL has the filename parameter, it will be used as the file name when downloaded.

Example:
 
            Storage::disk('local')->temporaryUrl($path, now()->addMinutes(5),  ['filename' => $filename]);